### PR TITLE
Comment image mp

### DIFF
--- a/rareapi/views/comment_view.py
+++ b/rareapi/views/comment_view.py
@@ -96,7 +96,7 @@ class PostAuthorSerializer(serializers.ModelSerializer):
     """
     class Meta:
         model = Author
-        fields = ('id', 'full_name')
+        fields = ('id', 'full_name', 'profile_image_url')
 
 
 class CommentSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
Closes #


# Description of Proposed Changes

Added profile image to PostAuthorSerializer in comment_view
---


# Steps to Test

1. Fetch the `comment-image-MP` branch and switch to it
2. Run debugger and open postman
3. Get comments and verify profile_image_url is part of expanded author

